### PR TITLE
Refresh dependencies, update to grafana-client >= 5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## Unreleased
+* Refreshed dependencies:
+  * Update to grafana-client >= 5
+  * Relax dependency pinning for Jinja2, python-dateutil, and PyYAML
+  * Remove dependency on setuptools
+
 ## 0.2.1 (2022-09-11)
 * fixe error on grafana datasources: the datatype returned by the API changed with grafana new version [issues #2](../../issues/2).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-grafana_client==2.1.0
-Jinja2==3.0.3
-python_dateutil==2.8.2
-PyYAML==6.0
-setuptools==39.2.0
+grafana-client>=5,<6
+Jinja2>=3,<3.2
+python-dateutil<3
+PyYAML>=5,<7


### PR DESCRIPTION
- Update to grafana-client >= 5
- Relax dependency pinning for Jinja2, python-dateutil, and PyYAML
- Remove dependency on setuptools