### PR TITLE
Discard the healthchecks value

### DIFF
--- a/grafana_snapshots/grafana.py
+++ b/grafana_snapshots/grafana.py
@@ -112,13 +112,9 @@ class Grafana(object):
             except ConnectionError:
                 raise Exception("Connecting to Grafana failed")
 
-        #* try to connect to the API
-        try:
-            res = self.grafana_api.health.check()
-            if res['database'] != 'ok':
-                raise Exception('grafana is not UP')
-        except:
-            raise
+        #* try to connect to the API - This will throw if it fails
+        # res["database"] doesn't return on Grafana 12
+        _ = self.grafana_api.health.check()
 
         self.version = Version(self.grafana_api.version)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ grafana-client>=5,<6
 Jinja2>=3,<3.2
 python-dateutil<3
 PyYAML>=5,<7
+requests


### PR DESCRIPTION
The database field is missing in Grafana 12, and we can remove the try catch, as if the function throws an error it will just bubble up to the top anyway.